### PR TITLE
add dig option for looking up ip addr

### DIFF
--- a/network_utils.py
+++ b/network_utils.py
@@ -1,15 +1,54 @@
 import socket
+import subprocess
 
 FORMAT = "utf-8"
 PORT = 5555
 
 
+def dig(*args):
+    cmd = ["dig"] + list(*args)
+    output = subprocess.check_output(cmd)
+    return output.strip().decode()
+
+
+def dig_get_host_name():
+    """Run dig command to find public IP
+    Seems to work on both DO ubuntu droplet and adam mac
+
+    If FileNotFoundError -> no dig command found
+    If ValueError -> dig command ran but returned empty
+    """
+    dig_args = ["+short", "myip.opendns.com", "@resolver1.opendns.com"]
+    addr = dig(dig_args)
+
+    # i've had cases of cmd running w/o error, but
+    # returning blank bytes object, throwing error in this case
+    if not addr:
+        raise ValueError
+
+    return addr
+
+
 def get_host_name(default="127.0.0.1"):
     """Try to get host name and fall back to defaults"""
     try:
+        return dig_get_host_name()
+    except (FileNotFoundError, ValueError):
+        pass
+
+    try:
         return socket.gethostbyname(socket.gethostname())
     except socket.gaierror:
-        try:
-            return socket.gethostbyname(socket.gethostname() + ".local")
-        except socket.gaierror:
-            return default
+        pass
+
+    try:
+        return socket.gethostbyname(socket.gethostname() + ".local")
+    except socket.gaierror:
+        pass
+
+    return default
+
+
+if __name__ == "__main__":
+    ip_addr = get_host_name()
+    print(f"Best guess for current box's address:\n{ip_addr}")

--- a/network_utils.py
+++ b/network_utils.py
@@ -5,8 +5,8 @@ FORMAT = "utf-8"
 PORT = 5555
 
 
-def dig(*args):
-    cmd = ["dig"] + list(*args)
+def dig(args):
+    cmd = ["dig"] + args
     output = subprocess.check_output(cmd)
     return output.strip().decode()
 


### PR DESCRIPTION
Rested on droplet and it's able to set itself up now by running `python3 server.py`; no need to explicitly put the address in `server.py`.   Not sure best practice on how the client knows the address ¯\\\_(ツ)\_/¯